### PR TITLE
Found a temporary fix to the infinite scrolling bug on laptops

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -25,3 +25,8 @@ body,
 ::-webkit-scrollbar-track:hover {
   background: #2a2b2f;
 }
+
+/* temporary solution to infinite scrolling on laptops */
+.recharts-wrapper {
+  overflow: auto; 
+} 


### PR DESCRIPTION
Summary of Changes

- Added the following CSS rule to the .recharts-wrapper class because I noticed the .recharts-wrapper class has something to do with the bug because max-height kept increasing.

Notes:
- I noticed that the bug only occurred on laptops. When I looked at the project from the tablets and phones perspectives on devtools, everything looked fine.
- Although the bug was resolved, the charts don't look good.